### PR TITLE
fix ottersec audit

### DIFF
--- a/contracts/protocol/sources/app/app.move
+++ b/contracts/protocol/sources/app/app.move
@@ -11,6 +11,7 @@ module protocol::app {
   use protocol::risk_model::{Self, RiskModels, RiskModel};
   use protocol::limiter::{Self, LimiterUpdateParamsChange, LimiterUpdateLimitChange};
   use protocol::incentive_rewards;
+  use protocol::error;
   use whitelist::whitelist;
   use protocol::obligation_access::ObligationAccessStore;
   use protocol::obligation_access;
@@ -119,6 +120,11 @@ module protocol::app {
     min_borrow_amount: u64,
     ctx: &mut TxContext,
   ): OneTimeLockValue<InterestModel> {
+    assert!(mid_kink <= high_kink, error::interest_model_param_error());
+    assert!(base_rate_per_sec <= borrow_rate_on_mid_kink, error::interest_model_param_error());
+    assert!(borrow_rate_on_mid_kink <= borrow_rate_on_high_kink, error::interest_model_param_error());
+    assert!(borrow_rate_on_high_kink <= max_borrow_rate, error::interest_model_param_error());
+
     let interest_model_change = interest_model::create_interest_model_change<T>(
       &admin_cap.interest_model_cap,
       base_rate_per_sec,

--- a/contracts/protocol/sources/app/app.move
+++ b/contracts/protocol/sources/app/app.move
@@ -11,7 +11,6 @@ module protocol::app {
   use protocol::risk_model::{Self, RiskModels, RiskModel};
   use protocol::limiter::{Self, LimiterUpdateParamsChange, LimiterUpdateLimitChange};
   use protocol::incentive_rewards;
-  use protocol::error;
   use whitelist::whitelist;
   use protocol::obligation_access::ObligationAccessStore;
   use protocol::obligation_access;
@@ -120,11 +119,6 @@ module protocol::app {
     min_borrow_amount: u64,
     ctx: &mut TxContext,
   ): OneTimeLockValue<InterestModel> {
-    assert!(mid_kink <= high_kink, error::interest_model_param_error());
-    assert!(base_rate_per_sec <= borrow_rate_on_mid_kink, error::interest_model_param_error());
-    assert!(borrow_rate_on_mid_kink <= borrow_rate_on_high_kink, error::interest_model_param_error());
-    assert!(borrow_rate_on_high_kink <= max_borrow_rate, error::interest_model_param_error());
-
     let interest_model_change = interest_model::create_interest_model_change<T>(
       &admin_cap.interest_model_cap,
       base_rate_per_sec,

--- a/contracts/protocol/sources/error/error.move
+++ b/contracts/protocol/sources/error/error.move
@@ -53,6 +53,7 @@ module protocol::error {
 
   // risk model & interest model errors
   public fun risk_model_param_error(): u64 { 0x0013001 }
+  public fun interest_model_param_error(): u64 { 0x0013002 }
 
   // pool liquidity errors
   public fun pool_liquidity_not_enough_error(): u64 { 0x0014001 }

--- a/contracts/protocol/sources/evaluator/liquidation_evaluator.move
+++ b/contracts/protocol/sources/evaluator/liquidation_evaluator.move
@@ -61,7 +61,6 @@ module protocol::liquidation_evaluator {
     let debt_type = type_name::get<DebtType>();
 
     // get all the necessary parameters for liquidation
-    obligation::debt(obligation, debt_type);
     let collateral_type = type_name::get<CollateralType>();
     let total_collateral_amount = obligation::collateral(obligation, collateral_type);
     let collateral_decimals = coin_decimals_registry::decimals(coin_decimals_registry, collateral_type);

--- a/contracts/protocol/sources/market/interest_model.move
+++ b/contracts/protocol/sources/market/interest_model.move
@@ -83,6 +83,11 @@ module protocol::interest_model {
     change_delay: u64,
     ctx: &mut TxContext,
   ): OneTimeLockValue<InterestModel> {
+    assert!(mid_kink <= high_kink, error::interest_model_param_error());
+    assert!(base_rate_per_sec <= borrow_rate_on_mid_kink, error::interest_model_param_error());
+    assert!(borrow_rate_on_mid_kink <= borrow_rate_on_high_kink, error::interest_model_param_error());
+    assert!(borrow_rate_on_high_kink <= max_borrow_rate, error::interest_model_param_error());
+
     let base_borrow_rate_per_sec = fixed_point32::create_from_rational(base_rate_per_sec, scale);
     let borrow_rate_on_mid_kink = fixed_point32::create_from_rational(borrow_rate_on_mid_kink, scale);
     let mid_kink = fixed_point32::create_from_rational(mid_kink, scale);
@@ -152,12 +157,12 @@ module protocol::interest_model {
     /* ================== Interest Rate Formula ==================
 
     Calculate the interest rate with the given utlilization rate of the pool
-    if ulti_rate <= mid_kink:
+    if util_rate <= mid_kink:
       interest_rate = (util_rate / mid_kink) * (borrow_rate_on_mid_kink - base_rate) + base_rate
-    else if ulti_rate <= high_kink:
+    else if util_rate <= high_kink:
       interest_rate = ((util_rate - mid_kink) / (high_kink - mid_kink)) * (borrow_rate_on_high_kink - borrow_rate_on_mid_kink) + borrow_rate_on_mid_kink
     else:
-      interest_rate = ((util_rate - high_kink) / (100 - high_kink)) * (max_borrow_rate - borrow_rate_on_high_kink) + borrow_rate_on_high_kink
+      interest_rate = ((util_rate - high_kink) / (1 - high_kink)) * (max_borrow_rate - borrow_rate_on_high_kink) + borrow_rate_on_high_kink
 
     ============================================================== */
 

--- a/contracts/protocol/sources/market/market.move
+++ b/contracts/protocol/sources/market/market.move
@@ -223,13 +223,15 @@ module protocol::market {
     update_interest_rates(self);
   }
   
-  public(friend) fun handle_liquidation<T>(
+  public(friend) fun handle_liquidation<DebtType, CollateralType>(
     self: &mut Market,
-    balance: Balance<T>,
-    revenue_balance: Balance<T>,
+    balance: Balance<DebtType>,
+    revenue_balance: Balance<DebtType>,
+    liquidate_amount: u64, // liquidate amount of the collateral
   ) {
     // We don't accrue interest here, because it has already been accrued in previous step for liquidation
     reserve::handle_liquidation(&mut self.vault, balance, revenue_balance);
+    collateral_stats::decrease(&mut self.collateral_stats, get<CollateralType>(), liquidate_amount);
     update_interest_rates(self);
   }
   

--- a/contracts/protocol/sources/user/liquidate.move
+++ b/contracts/protocol/sources/user/liquidate.move
@@ -86,6 +86,7 @@ module protocol::liquidate {
     // Reduce the debt for the obligation
     let debt_type = type_name::get<DebtType>();
     obligation::decrease_debt(obligation, debt_type, repay_on_behalf);
+    market::handle_inflow<DebtType>(market, repay_on_behalf, now);
     
     // Put the repay and revenue balance to the market
     let repay_on_behalf_balance = balance::split(&mut available_repay_balance, repay_on_behalf);

--- a/contracts/protocol/sources/user/liquidate.move
+++ b/contracts/protocol/sources/user/liquidate.move
@@ -90,7 +90,7 @@ module protocol::liquidate {
     // Put the repay and revenue balance to the market
     let repay_on_behalf_balance = balance::split(&mut available_repay_balance, repay_on_behalf);
     let revenue_balance = balance::split(&mut available_repay_balance, repay_revenue);
-    market::handle_liquidation(market, repay_on_behalf_balance, revenue_balance);
+    market::handle_liquidation<DebtType, CollateralType>(market, repay_on_behalf_balance, revenue_balance, liq_amount);
 
     emit(LiquidateEvent {
       liquidator: tx_context::sender(ctx),

--- a/contracts/sui_x_oracle/pyth_rule/sources/pyth_adaptor.move
+++ b/contracts/sui_x_oracle/pyth_rule/sources/pyth_adaptor.move
@@ -19,6 +19,7 @@ module pyth_rule::pyth_adaptor {
   const PYTH_PRICE_DECIMALS_TOO_LARGE: u64 = 0x11201;
   const PYTH_PRICE_TOO_OLD: u64 = 0x11202;
   const PYTH_PRICE_TOO_NEW: u64 = 0x11203;
+  const PYTH_PRICE_CONF_TOO_LARGE: u64 = 0x11299;
 
   public fun get_pyth_price(
     wormhole_state: &WormholeState,
@@ -50,6 +51,8 @@ module pyth_rule::pyth_adaptor {
     assert!(price_decimals <= U8_MAX, PYTH_PRICE_DECIMALS_TOO_LARGE);
     // Make sure price is fresh
     assert_price_not_stale(&pyth_price, clock);
+    // Make sure price confidence is within range
+    assert_price_conf_within_range(price_value, price_conf);
     let price_decimals = (price_decimals as u8);
     (price_value, price_conf, price_decimals, price_updated_time)
   }
@@ -60,5 +63,13 @@ module pyth_rule::pyth_adaptor {
     let now = clock::timestamp_ms(clock) /1000;
     assert!(price_updated_time <= now + 10, PYTH_PRICE_TOO_NEW);
     assert!(price_updated_time >= now - 60, PYTH_PRICE_TOO_OLD);
+  }
+
+  fun assert_price_conf_within_range(price_value: u64, price_conf: u64) {
+    // Check price confidence is within range
+    let base = 10000;
+    let price_conf_range = 2 * base; // 2% of price
+    let price_conf_diff = (price_conf * base * 100 as u128) / (price_value as u128);
+    assert!((price_conf_diff as u64) <= price_conf_range, PYTH_PRICE_CONF_TOO_LARGE);
   }
 }

--- a/contracts/sui_x_oracle/supra_rule/sources/supra_registry.move
+++ b/contracts/sui_x_oracle/supra_rule/sources/supra_registry.move
@@ -20,16 +20,16 @@ module supra_rule::supra_registry {
   }
 
   fun init(ctx: &mut TxContext) {
-    let pyth_registry = SupraRegistry {
+    let supra_registry = SupraRegistry {
       id: object::new(ctx),
       table: table::new(ctx)
     };
-    let pyth_registry_cap = SupraRegistryCap {
+    let supra_registry_cap = SupraRegistryCap {
       id: object::new(ctx),
-      for: object::id(&pyth_registry)
+      for: object::id(&supra_registry)
     };
-    transfer::share_object(pyth_registry);
-    transfer::transfer(pyth_registry_cap, tx_context::sender(ctx));
+    transfer::share_object(supra_registry);
+    transfer::transfer(supra_registry_cap, tx_context::sender(ctx));
   }
 
   public entry fun register_supra_pair_id<CoinType>(

--- a/contracts/test/sources/constants.move
+++ b/contracts/test/sources/constants.move
@@ -1,4 +1,5 @@
 module protocol_test::constants {
+  use math::u64;
   use sui::math;
   use test_coin::eth::ETH;
   use test_coin::btc::BTC;
@@ -71,18 +72,25 @@ module protocol_test::constants {
   }
   
   public fun usdc_interest_model_params(): InterestModelParams<USDC> {
+    let interest_rate_scale = math::pow(10, 7);
+    let scale = math::pow(10, 12);
+    let secs_per_year = 365 * 24 * 60 * 60;
+
+    let borrow_rate_on_mid_kink = 8 * u64::mul_div(scale, interest_rate_scale, secs_per_year) / 100;
+    let borrow_rate_on_high_kink = 50 * u64::mul_div(scale, interest_rate_scale, secs_per_year) / 100;
+    let max_borrow_rate = 300 * u64::mul_div(scale, interest_rate_scale, secs_per_year) / 100;
     InterestModelParams {
-      base_rate_per_sec: 6341958397,
-      interest_rate_scale: 10000000,
-      borrow_rate_on_mid_kink: 8 * math::pow(10, 10),
-      mid_kink: 60 * math::pow(10, 10),
-      borrow_rate_on_high_kink: 50 * math::pow(10, 12),
-      high_kink: 90 * math::pow(10, 10),
-      max_borrow_rate: 300 * math::pow(10, 10),
-      revenue_factor: 2 * math::pow(10, 10),
-      scale: math::pow(10, 12),
+      base_rate_per_sec: 0,
+      interest_rate_scale,
+      borrow_rate_on_mid_kink,
+      borrow_rate_on_high_kink,
+      max_borrow_rate,
+      mid_kink: u64::mul_div(60, scale, 100),
+      high_kink: u64::mul_div(90, scale, 100),
+      revenue_factor: u64::mul_div(2, scale, 100),
+      scale,
       min_borrow_amount: math::pow(10, 8),
-      borrow_weight: math::pow(10, 12),
+      borrow_weight: 1 * scale,
     }
   }
 }

--- a/contracts/test/sources/test_cases/borrow_index_test.move
+++ b/contracts/test/sources/test_cases/borrow_index_test.move
@@ -1,0 +1,122 @@
+#[test_only]
+module protocol_test::borrow_index_test {
+
+  use std::fixed_point32;
+  use std::type_name;
+  use sui::test_scenario;
+  use sui::coin;
+  use sui::math;
+  use sui::clock;
+  use x_oracle::x_oracle;
+  use coin_decimals_registry::coin_decimals_registry;
+  use math::fixed_point32_empower;
+  use math::u64;
+  use protocol::version;
+  use protocol::borrow;
+  use protocol::deposit_collateral;
+  use protocol::mint;
+  use protocol::accrue_interest;
+  use protocol::market;
+  use protocol_test::app_t::app_init;
+  use protocol_test::open_obligation_t::open_obligation_t;
+  use protocol_test::constants::{usdc_interest_model_params, eth_risk_model_params};
+  use protocol_test::oracle_t;
+  use protocol_test::coin_decimals_registry_t::coin_decimals_registry_init;
+  use protocol_test::interest_model_t::add_interest_model_t;
+  use protocol_test::risk_model_t::add_risk_model_t;
+  use test_coin::eth::ETH;
+  use test_coin::usdc::USDC;
+  
+  #[test]
+  public fun borrow_index_test() {
+    // Scenario:
+    // 0. the price of USDC = $1 and the price of ETH = $1000
+    // 1. `lender` deposit 10000 USDC
+    // 2. `borrower` deposit collateral 1 ETH
+    // 3. `borrower` borrow 699 USDC
+    //    - this action is success, because the collateral of the borrower is worth of 1000 USD. 
+    //      and 699 USDC borrow still satisfy 0.7 collateral factor
+
+    let usdc_decimals = 9;
+    let eth_decimals = 9;
+    
+    let admin = @0xAD;
+    let lender = @0xAA;
+    let borrower = @0xBB;
+    let scenario_value = test_scenario::begin(admin);
+    let scenario = &mut scenario_value;
+    let clock = clock::create_for_testing(test_scenario::ctx(scenario));
+    let version = version::create_for_testing(test_scenario::ctx(scenario));
+    let (market, admin_cap) = app_init(scenario);
+    let usdc_interest_params = usdc_interest_model_params();
+
+    let (x_oracle, x_oracle_policy_cap) = oracle_t::init_t(scenario);
+
+    test_scenario::next_tx(scenario, admin);
+    
+    clock::set_for_testing(&mut clock, 100 * 1000);
+    add_interest_model_t<USDC>(scenario, math::pow(10, 18), 60 * 60 * 24, 30 * 60, &mut market, &admin_cap, &usdc_interest_params, &clock);
+    let eth_risk_params = eth_risk_model_params();
+    add_risk_model_t<ETH>(scenario, &mut market, &admin_cap, &eth_risk_params);
+    let coin_decimals_registry = coin_decimals_registry_init(scenario);
+    coin_decimals_registry::register_decimals_t<USDC>(&mut coin_decimals_registry, usdc_decimals);
+    coin_decimals_registry::register_decimals_t<ETH>(&mut coin_decimals_registry, eth_decimals);
+    
+    test_scenario::next_tx(scenario, lender);
+    let usdc_amount = math::pow(10, usdc_decimals + 4);
+    clock::set_for_testing(&mut clock, 200 * 1000);
+    let usdc_coin = coin::mint_for_testing<USDC>(usdc_amount, test_scenario::ctx(scenario));
+    let market_coin = mint::mint(&version, &mut market, usdc_coin, &clock, test_scenario::ctx(scenario));
+    assert!(coin::value(&market_coin) == usdc_amount, 0);
+    coin::burn_for_testing(market_coin);
+    
+    test_scenario::next_tx(scenario, borrower);
+    let eth_amount = math::pow(10, eth_decimals + 4);
+    let eth_coin = coin::mint_for_testing<ETH>(eth_amount, test_scenario::ctx(scenario));
+    let (obligation, obligation_key) = open_obligation_t(scenario, &version);
+    deposit_collateral::deposit_collateral(&version, &mut obligation, &mut market, eth_coin, test_scenario::ctx(scenario));
+  
+    clock::set_for_testing(&mut clock, 300 * 1000);
+    x_oracle::update_price<USDC>(&mut x_oracle, &clock, oracle_t::calc_scaled_price(1, 0)); // $1
+    x_oracle::update_price<ETH>(&mut x_oracle, &clock, oracle_t::calc_scaled_price(1000, 0)); // $1000
+
+    test_scenario::next_tx(scenario, borrower);
+    let borrow_amount = math::pow(10, usdc_decimals + 4);
+    let borrowed = borrow::borrow<USDC>(&version, &mut obligation, &obligation_key, &mut market, &coin_decimals_registry, borrow_amount, &x_oracle, &clock, test_scenario::ctx(scenario));
+    assert!(coin::value(&borrowed) == borrow_amount, 0);
+    coin::burn_for_testing(borrowed);
+
+    test_scenario::next_tx(scenario, borrower);
+    let initial_borrow_index = market::borrow_index(&market, type_name::get<USDC>());
+
+    let time = 60 * 60 * 24 * 365 * 1000 + 300 * 1000;
+    clock::set_for_testing(&mut clock, time);
+    accrue_interest::accrue_interest_for_market(&version, &mut market, &clock);
+    let borrow_index = market::borrow_index(&market, type_name::get<USDC>());
+    let expected_borrow_index = 4 * initial_borrow_index;
+    let index_diff = if (borrow_index > expected_borrow_index) {
+      borrow_index - expected_borrow_index
+    } else {
+      expected_borrow_index - borrow_index
+    };
+    let index_diff_rate = fixed_point32::create_from_rational(index_diff, expected_borrow_index);
+    let index_precision = fixed_point32::create_from_rational(1, math::pow(10, 8));
+    assert!(
+      fixed_point32_empower::gte(index_precision, index_diff_rate),
+      0
+    );
+
+
+    clock::destroy_for_testing(clock);
+    version::destroy_for_testing(version);
+
+    test_scenario::return_shared(x_oracle);
+    test_scenario::return_shared(coin_decimals_registry);
+    test_scenario::return_shared(market);
+    test_scenario::return_shared(obligation);
+    test_scenario::return_to_address(admin, x_oracle_policy_cap);
+    test_scenario::return_to_address(admin, admin_cap);
+    test_scenario::return_to_address(borrower, obligation_key);
+    test_scenario::end(scenario_value);
+  }
+}

--- a/contracts/test/sources/test_cases/borrow_index_test.move
+++ b/contracts/test/sources/test_cases/borrow_index_test.move
@@ -10,7 +10,6 @@ module protocol_test::borrow_index_test {
   use x_oracle::x_oracle;
   use coin_decimals_registry::coin_decimals_registry;
   use math::fixed_point32_empower;
-  use math::u64;
   use protocol::version;
   use protocol::borrow;
   use protocol::deposit_collateral;


### PR DESCRIPTION
## Description
- liquidate an obligation also means repaying the debt, hence we should add `handle_inflow` just like we did in repay action https://github.com/scallop-io/sui-lending-protocol/commit/871ef5131141b5aa96b97490069aa429a55f59f6 
- Collateral stats contains the sum of all collateral balance in the protocol, when doing liquidation the collateral of the particular obligation is taken to repay debt, hence the collateral stats also should be deducted https://github.com/scallop-io/sui-lending-protocol/commit/05c4777a38eacfb844f7e3f3bc25cd3b0c5aa771 

## Update July 22
- assert price confidence of pyth https://github.com/scallop-io/sui-lending-protocol/pull/57/commits/82bcb6b8c8e8835ce80b26c86ab02f24d7e0089e