### PR TITLE
feat: block looping same assets

### DIFF
--- a/contracts/protocol/sources/error/error.move
+++ b/contracts/protocol/sources/error/error.move
@@ -26,6 +26,7 @@ module protocol::error {
   public fun borrow_too_much_error(): u64 { 0x0000501 }
   public fun borrow_too_small_error(): u64 { 0x0000502 }
   public fun flash_loan_repay_not_enough_error(): u64 { 0x0000503 }
+  public fun unable_to_borrow_a_collateral_coin(): u64 { 0x0000504 }
 
   // liquidation
   public fun unable_to_liquidate_error(): u64 { 0x0000601 }
@@ -34,6 +35,7 @@ module protocol::error {
   public fun max_collateral_reached_error(): u64 { 0x0000701 }
   public fun invalid_collateral_type_error(): u64 { 0x0000702 }
   public fun withdraw_collateral_too_much_error(): u64 { 0x0000703 }
+  public fun unable_to_deposit_a_borrowed_coin(): u64 { 0x0000704 }
 
   // market coin error
   public fun mint_market_coin_too_small_error(): u64 { 0x0000801 }

--- a/contracts/protocol/sources/obligation/obligation.move
+++ b/contracts/protocol/sources/obligation/obligation.move
@@ -197,8 +197,16 @@ module protocol::obligation {
     obligation_debts::decrease(&mut self.debts, type_name, amount);
   }
 
+  public fun has_coin_x_as_debt(self: &Obligation, coin_type: TypeName): bool {
+    obligation_debts::has_coin_x_as_debt(&self.debts, coin_type)
+  }
+
   public fun debt(self: &Obligation, type_name: TypeName): (u64, u64) {
     obligation_debts::debt(&self.debts, type_name)
+  }
+
+  public fun has_coin_x_as_collateral(self: &Obligation, coin_type: TypeName): bool {
+    obligation_collaterals::has_coin_x_as_collateral(&self.collaterals, coin_type)
   }
   
   public fun collateral(self: &Obligation, type_name: TypeName): u64 {

--- a/contracts/protocol/sources/obligation/obligation_collaterals.move
+++ b/contracts/protocol/sources/obligation/obligation_collaterals.move
@@ -45,6 +45,18 @@ module protocol::obligation_collaterals {
       wit_table::remove(ObligationCollaterals{}, collaterals, type_name);
     }
   }
+
+  public(friend) fun has_coin_x_as_collateral(
+    collaterals: &WitTable<ObligationCollaterals, TypeName, Collateral>,
+    coin_type: TypeName,
+  ): bool {
+    if (wit_table::contains(collaterals, coin_type)) {
+      let collateral_amount = collateral(collaterals, coin_type);
+      collateral_amount > 0
+    } else {
+      false
+    }
+  }
   
   public fun collateral(
     collaterals: &WitTable<ObligationCollaterals, TypeName, Collateral>,

--- a/contracts/protocol/sources/obligation/obligation_debts.move
+++ b/contracts/protocol/sources/obligation/obligation_debts.move
@@ -17,6 +17,18 @@ module protocol::obligation_debts {
   public(friend) fun new(ctx: &mut TxContext): WitTable<ObligationDebts, TypeName, Debt> {
     wit_table::new(ObligationDebts{}, true, ctx)
   }
+
+  public(friend) fun has_coin_x_as_debt(
+    debts: &WitTable<ObligationDebts, TypeName, Debt>,
+    coin_type: TypeName,
+  ): bool {
+    if (wit_table::contains(debts, coin_type)) {
+      let (debt_amount, _debt_borrow_index) = debt(debts, coin_type);
+      debt_amount > 0
+    } else {
+      false
+    }
+  }
   
   public(friend) fun init_debt(
     debts: &mut WitTable<ObligationDebts, TypeName, Debt>,

--- a/contracts/protocol/sources/user/borrow.move
+++ b/contracts/protocol/sources/user/borrow.move
@@ -93,6 +93,8 @@ module protocol::borrow {
 
     let now = clock::timestamp_ms(clock) / 1000;
     obligation::assert_key_match(obligation, obligation_key);
+
+    assert!(!obligation::has_coin_x_as_collateral(obligation, coin_type), error::unable_to_borrow_a_collateral_coin());
   
     let interest_model = market::interest_model(market, coin_type);
     let min_borrow_amount = interest_model::min_borrow_amount(interest_model);

--- a/contracts/protocol/sources/user/deposit_collateral.move
+++ b/contracts/protocol/sources/user/deposit_collateral.move
@@ -47,6 +47,8 @@ module protocol::deposit_collateral {
 
     let has_risk_model = market::has_risk_model(market, coin_type);
     assert!(has_risk_model == true, error::invalid_collateral_type_error());
+
+    assert!(!obligation::has_coin_x_as_debt(obligation, coin_type), error::unable_to_deposit_a_borrowed_coin());
     
     emit(CollateralDepositEvent{
       provider: tx_context::sender(ctx),

--- a/contracts/test/sources/app.move
+++ b/contracts/test/sources/app.move
@@ -22,6 +22,19 @@ module protocol_test::app_t {
       test_scenario::ctx(scenario)
     );
 
+    app::update_borrow_fee<USDC>(
+      &adminCap,
+      &mut market,
+      0,
+      1
+    );
+
+    app::update_borrow_fee_recipient(
+      &adminCap,
+      &mut market,
+      sender
+    );
+
     whitelist::allow_all(app::ext(&adminCap, &mut market));
 
     (market, adminCap)


### PR DESCRIPTION
## Description
Using coin `X` as collateral and borrow out coin `X` will be not possible. The transaction will be aborted.